### PR TITLE
Refactor 'expand_user_path' function

### DIFF
--- a/Uninstallomator.sh
+++ b/Uninstallomator.sh
@@ -71,8 +71,8 @@ if [[ $(/usr/bin/arch) == "arm64" ]]; then
         rosetta2=no
     fi
 fi
-VERSION="1.1.3"
-VERSIONDATE="2025-09-11"
+VERSION="1.1.4"
+VERSIONDATE="2025-09-25"
 
 
 # MARK: Functions
@@ -207,8 +207,9 @@ list_user_homes(){
   | sort -u | grep -E '^/Users/[^/]+' | grep -vE '^/Users/(Shared|Guest)$'
 }
 expand_user_path(){
-  local tpl="$1" home="$2"
-  printf '%s' "${tpl//%USER_HOME%/$home}"
+  local tpl="$1" home="$2" pattern="%USER_HOME%"
+  setopt localoptions sh_glob
+  printf '%s' "${tpl//${pattern}/$home}"
 }
 
 # --- Uninstall engine (runs after label case sets arrays) ---


### PR DESCRIPTION
In (at least) macOS 26 (25A354), `%USER_HOME%` wasn't actually expanding to the currently logged-in user:

```
root@XDT8675309-22AE57 dan # zsh /Users/dan/Desktop/Uninstallomator.zsh intellijidea
2025-09-25 05:36:09 : INFO : intellijidea : Total items in argumentsArray: 0
2025-09-25 05:36:09 : INFO : intellijidea : argumentsArray: 
2025-09-25 05:36:10 : REQ : intellijidea : ################## Start Uninstallomator
2025-09-25 05:36:10 : INFO : intellijidea : ################## Version: 1.1.3
2025-09-25 05:36:10 : INFO : intellijidea : ################## Date: 2025-09-11
2025-09-25 05:36:10 : INFO : intellijidea : ################## intellijidea
2025-09-25 05:36:10 : DEBUG : intellijidea : DEBUG mode 1 enabled.
2025-09-25 05:36:10 : INFO : intellijidea : Reading arguments again: 
2025-09-25 05:36:10 : DEBUG : intellijidea : app_name: IntelliJ IDEA
2025-09-25 05:36:10 : DEBUG : intellijidea : bundle_id: com.jetbrains.intellij
2025-09-25 05:36:10 : DEBUG : intellijidea : app_paths: /Applications/IntelliJ IDEA.app
2025-09-25 05:36:10 : DEBUG : intellijidea : pkgs: 
2025-09-25 05:36:10 : DEBUG : intellijidea : files: 
2025-09-25 05:36:10 : DEBUG : intellijidea : user_files: %USER_HOME%/Library/Application Support/IntelliJ IDEA %USER_HOME%/Library/Application Support/JetBrains %USER_HOME%/Library/Preferences/com.jetbrains.intellij.plist %USER_HOME%/Library/Caches/com.jetbrains.intellij %USER_HOME%/Library/Logs/IntelliJ IDEA %USER_HOME%/IdeaSnapshots
2025-09-25 05:36:10 : DEBUG : intellijidea : agents: 
2025-09-25 05:36:10 : DEBUG : intellijidea : daemons: 
2025-09-25 05:36:10 : DEBUG : intellijidea : profiles: 
2025-09-25 05:36:10 : INFO : intellijidea : NOTIFY=silent
2025-09-25 05:36:10 : INFO : intellijidea : LOGGING=DEBUG
2025-09-25 05:36:10 : INFO : intellijidea : no blocking processes defined
2025-09-25 05:36:10 : INFO : intellijidea : Uninstalling IntelliJ IDEA (com.jetbrains.intellij)
2025-09-25 05:36:10 : DEBUG : intellijidea : DEBUG mode: skipping blocking process checks
2025-09-25 05:36:10 : DEBUG : intellijidea : [DEBUG] would remove: /Applications/IntelliJ IDEA.app
+expand_user_path:2> local tpl='%USER_HOME%/Library/Application Support/IntelliJ IDEA' home=/Users/dan
+expand_user_path:3> printf %s '%USER_HOME%/Library/Application Support/IntelliJ IDEA'
+expand_user_path:4> set +x
+expand_user_path:2> local tpl='%USER_HOME%/Library/Application Support/JetBrains' home=/Users/dan
+expand_user_path:3> printf %s '%USER_HOME%/Library/Application Support/JetBrains'
+expand_user_path:4> set +x
+expand_user_path:2> local tpl=%USER_HOME%/Library/Preferences/com.jetbrains.intellij.plist home=/Users/dan
+expand_user_path:3> printf %s %USER_HOME%/Library/Preferences/com.jetbrains.intellij.plist
+expand_user_path:4> set +x
+expand_user_path:2> local tpl=%USER_HOME%/Library/Caches/com.jetbrains.intellij home=/Users/dan
+expand_user_path:3> printf %s %USER_HOME%/Library/Caches/com.jetbrains.intellij
+expand_user_path:4> set +x
+expand_user_path:2> local tpl='%USER_HOME%/Library/Logs/IntelliJ IDEA' home=/Users/dan
+expand_user_path:3> printf %s '%USER_HOME%/Library/Logs/IntelliJ IDEA'
+expand_user_path:4> set +x
+expand_user_path:2> local tpl=%USER_HOME%/IdeaSnapshots home=/Users/dan
+expand_user_path:3> printf %s %USER_HOME%/IdeaSnapshots
+expand_user_path:4> set +x
2025-09-25 05:36:10 : ERROR : intellijidea : Some app bundles still present for IntelliJ IDEA
2025-09-25 05:36:10 : REQ : intellijidea : ################## End Uninstallomator, exit code 1
```